### PR TITLE
Added mipmaps to textures for improved performance.

### DIFF
--- a/Assets/unZENity-VR/Scripts/Creator/MeshCreator.cs
+++ b/Assets/unZENity-VR/Scripts/Creator/MeshCreator.cs
@@ -71,10 +71,14 @@ namespace UZVR.Creator
                     return;
                 }
 
-                var texture = new Texture2D((int)pxTexture.width, (int)pxTexture.height, format, false);
+                var texture = new Texture2D((int)pxTexture.width, (int)pxTexture.height, format, (int)pxTexture.mipmapCount, false);
 
                 texture.name = bMaterial.texture;
-                texture.LoadRawTextureData(pxTexture.mipmaps[0].mipmap);
+
+                for (var i = 0u; i < pxTexture.mipmapCount; i++)
+                {
+                    texture.SetPixelData(pxTexture.mipmaps[i].mipmap, (int)i);
+                }
 
                 texture.Apply();
 


### PR DESCRIPTION
phoenix provides mipmaps from Gothic Assets. We will now use them to optimice CPU usage (at least I read it so...).

I checked: If I remove the loop and just add mipmaps for level=0, and zoom out in Editor, the textures become broken. If I have this loop, they're visible the right way. In other words: Mipmaps work.

(PS: Default Mipmap size of Unity was 9. Gothic delivers 6.)