### PR TITLE
As suggested in forum, we need to add specific DLL from unity install…

### DIFF
--- a/Assets/unZENity-VR/Dependencies/I18N.West.dll
+++ b/Assets/unZENity-VR/Dependencies/I18N.West.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d54fadf1f503babc484d706971641084be9d0b5563eb34e45f52e0ae270cd8c
+size 72704

--- a/Assets/unZENity-VR/Dependencies/I18N.West.dll.meta
+++ b/Assets/unZENity-VR/Dependencies/I18N.West.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 4cea24f98c7b25c4da5b2455c8735f6a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
…ation folder into the package being built.

References:
* https://answers.unity.com/questions/1728036/unity20193-and-i18ndll.html
* https://answers.unity.com/questions/1756912/invalid-il-code-in-build.html

As we call the Windows-1252 Encoding on the added PxCs.dll, I assume we need to add the Unity I18N.West.DLL manually as Unity isn't aware of our needs during build time.

Windows build works now (World is being generated again.)

Please test.